### PR TITLE
write expanded matrix to pyBCS

### DIFF
--- a/pyBCS/scanpy2bcs.py
+++ b/pyBCS/scanpy2bcs.py
@@ -1505,6 +1505,7 @@ def format_data(source, output_name, input_format="h5ad", raw_key="counts",
                 feature_name=None,
                 dimred_keys=None,
                 cite_seq_suffix=None,
+                expanded=False,
                 **kwargs):
     """Converts data to bcs format
 


### PR DESCRIPTION
To allow bcs file written by pyBCS to be unzipped directly into BBrowser without further processing.